### PR TITLE
Change imported posts to draft

### DIFF
--- a/includes/mailchimp-importer.php
+++ b/includes/mailchimp-importer.php
@@ -39,7 +39,7 @@ function mcpt_import_newsletter_from_url( $url ) {
     $post_id = wp_insert_post( array(
         'post_title'   => wp_strip_all_tags( $doc->getElementsByTagName( 'title' )->item(0)->textContent ),
         'post_content' => $content,
-        'post_status'  => 'publish',
+        'post_status'  => 'draft',
         'post_type'    => 'newsletter',
         'post_excerpt' => $excerpt,
     ) );

--- a/mailchimp-cpt.php
+++ b/mailchimp-cpt.php
@@ -2,7 +2,7 @@
 /**
  * Plugin Name: Mailchimp CPT Importer
  * Description: Import newsletters from Mailchimp or any URL and store them as a custom post type.
- * Version: 0.1.0
+ * Version: 0.1.1
  * Author: Rolando
  * License: GPL2
  */
@@ -23,6 +23,6 @@ require_once MCPT_PATH . 'admin/import-page.php';
 
 // Enqueue admin styles
 function mcpt_admin_enqueue() {
-    wp_enqueue_style( 'mcpt-admin', plugin_dir_url( __FILE__ ) . 'assets/css/admin-style.css', array(), '0.1.0' );
+    wp_enqueue_style( 'mcpt-admin', plugin_dir_url( __FILE__ ) . 'assets/css/admin-style.css', array(), '0.1.1' );
 }
 add_action( 'admin_enqueue_scripts', 'mcpt_admin_enqueue' );

--- a/readme.txt
+++ b/readme.txt
@@ -3,7 +3,7 @@ Contributors: rolandototo
 Tags: mailchimp, newsletter, import
 Requires at least: 5.0
 Tested up to: 6.5
-Stable tag: 0.1.0
+Stable tag: 0.1.1
 License: GPLv2 or later
 
 A simple plugin to import newsletters as a custom post type.


### PR DESCRIPTION
## Summary
- save imported newsletter posts as `draft`
- bump plugin version to `0.1.1`

## Testing
- `php -l includes/mailchimp-importer.php`
- `php -l mailchimp-cpt.php`


------
https://chatgpt.com/codex/tasks/task_e_684865fc9a08832ea7d94f64d96708a7